### PR TITLE
Simplify token message

### DIFF
--- a/bin/cli.js
+++ b/bin/cli.js
@@ -7,7 +7,7 @@ var ghauth = require('ghauth')
 var authOptions = {
   configName: 'gh-release',
   scopes: ['repo'],
-  note: 'This token is for gh-release',
+  note: 'gh-release',
   userAgent: 'gh-release'
 }
 var argv = require('yargs')


### PR DESCRIPTION
The `note` field is actually the display name in settings, so a shorter identifier is better.