### PR TITLE
expose `--dry-run` option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 This change log adheres to standards from [Keep a CHANGELOG](http://keepachangelog.com).
 
 ## [Unreleased]
+* add `dry-run` option
 * improve change log
 
 ## [1.1.1] - 2015-03-02

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -54,6 +54,10 @@ var yargs = require('yargs')
       type: 'boolean',
       default: false,
       describe: 'publish as prerelease'
+    },
+    'dry-run': {
+      type: 'boolean',
+      default: false
     }
   })
   .help('h')

--- a/index.js
+++ b/index.js
@@ -22,6 +22,10 @@ var questions = [
 ]
 
 function ghRelease (options, auth, callback) {
+  // save dry run value then remove from options
+  var dryRun = options.dryRun
+  delete options.dryRun
+
   if (auth && auth.token) {
     client.authenticate({
       type: 'oauth',
@@ -43,6 +47,8 @@ function ghRelease (options, auth, callback) {
     var releaseOptions = extend(defaults, options || {})
 
     console.log(releaseOptions)
+
+    if (dryRun) process.exit(0)
 
     inquirer.prompt(questions, function (answers) {
       if (!answers.confirm) {

--- a/lib/get-defaults.js
+++ b/lib/get-defaults.js
@@ -30,7 +30,8 @@ module.exports = function getDefaults (callback) {
       owner: owner,
       repo: repo,
       draft: false,
-      prerelease: false
+      prerelease: false,
+      dryRun: false
     })
   })
 }


### PR DESCRIPTION
This solves two things:

(1) Allows doing a dry run that spits out what would get sent to releases API and exits, e.g.

```
$ gh-release --dry-run
{ tag_name: 'v1.0.0',
  target_commitish: 'master',
  name: 'v1.0.0',
  body: '* init',
  owner: 'bilbo',
  repo: 'baggins',
  draft: false,
  prerelease: false }
```

(2) Allows refactoring `index.js` so prompts are handled exclusively by `bin/cli.js`.