### PR TITLE
Report error if release exists already

### DIFF
--- a/index.js
+++ b/index.js
@@ -67,7 +67,14 @@ function ghRelease (options, auth, callback) {
         } else {
           client.releases.createRelease(releaseOptions, function (err, res) {
             if (err) {
-              console.error(err)
+              var message = JSON.parse(err.message)
+              var tagExists = (message.errors[0].code === 'already_exists')
+              if (err.code === 422 && tagExists) {
+                console.log('A release already exists for the tag ' + releaseOptions.tag_name)
+                console.log('Try bumping the version in your package.json.\nThen push to ' + releaseOptions.owner + '/' + releaseOptions.repo + ' and try again.')
+              } else {
+                console.error(err)
+              }
               process.exit(1)
             }
             callback(null, res)


### PR DESCRIPTION
Ran into this today, so I thought I'd explicitly catch this error and make it easy to understand.
Now, if you run gh-release and the version in your package.json was already used for a release, an error appears with helpful instructions specific to your project:

```
A release already exists for the tag v0.0.3
Try bumping the version in your package.json.
Then push to paulcpederson/inline-block-grid and try again.
```