### PR TITLE
:bug: error if request for target commit is a 404

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 This change log adheres to [keepachangelog.com](http://keepachangelog.com).
 
+## [Unreleased] - 2015-08-11
+
+* if target commit returns a 404, throw error
+
 ## [2.0.0] - 2015-04-28
 
 ### Changed

--- a/index.js
+++ b/index.js
@@ -69,7 +69,7 @@ function Release (options, callback) {
   })
 
   request(getCommitOptions, function (err, res, body) {
-    if (err) {
+    if (err || res.statusCode === 404) {
       var errorMessage = format('Target commitish %s not found in %s/%s', options.target_commitish, options.owner, options.repo)
       return callback(new Error(errorMessage))
     }


### PR DESCRIPTION
We were checking for a request error, and throwing an informative error, but if your target commit is missing, GitHub actually just returns a 404. This applies the same error to 404s as well.