### PR TITLE
Use the most recently released version when comparing versions

### DIFF
--- a/bin/lib/get-defaults.js
+++ b/bin/lib/get-defaults.js
@@ -17,7 +17,7 @@ function getDefaults (workPath, callback) {
 
   changelogParser(logPath, function (err, result) {
     if (err) return callback(err)
-    var log = result.versions[0]
+    var log = result.versions.find(function (release) { return release.version !== null })
 
     if (log.version !== pkg.version) {
       var errStr = 'CHANGELOG.md out of sync with package.json '

--- a/bin/lib/get-defaults.js
+++ b/bin/lib/get-defaults.js
@@ -17,7 +17,7 @@ function getDefaults (workPath, callback) {
 
   changelogParser(logPath, function (err, result) {
     if (err) return callback(err)
-    var log = result.versions.find(function (release) { return release.version !== null })
+    var log = result.versions.filter(function (release) { return release.version !== null })[0]
 
     if (log.version !== pkg.version) {
       var errStr = 'CHANGELOG.md out of sync with package.json '

--- a/test/fixtures/unreleased/CHANGELOG.md
+++ b/test/fixtures/unreleased/CHANGELOG.md
@@ -1,0 +1,4 @@
+## Unreleased
+
+## 1.0.0
+- bananas

--- a/test/fixtures/unreleased/package.json
+++ b/test/fixtures/unreleased/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "gh-release-test",
+  "version": "1.0.0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/bcomnes/gh-release-test.git"
+  }
+}

--- a/test/index.js
+++ b/test/index.js
@@ -20,3 +20,12 @@ test('should return error if changelog version !== package.json version', functi
     t.deepEqual(err, new Error('CHANGELOG.md out of sync with package.json (0.0.0 !== 0.0.1)'))
   })
 })
+
+test('should ignore entries with invalid versions', function (t) {
+  t.plan(1)
+  ghRelease({
+    workpath: fixture('mismatch')
+  }, function (err, result) {
+    t.deepEqual(err, {})
+  })
+})


### PR DESCRIPTION
The prior behavior would error if you had an "unreleased" section at the top of your changelog.

I like to keep the section there, even empty, so that I don't have to remember to add it back in when I need to add an entry.

This finds the first changelog entry with a non-null version, rather than just the first changelog entry.